### PR TITLE
Wrap the headers in extern "C" so they can be used with c++

### DIFF
--- a/ykclient.h
+++ b/ykclient.h
@@ -33,6 +33,10 @@
 #ifndef YKCLIENT_H
 #define YKCLIENT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include <string.h>
 
@@ -113,5 +117,9 @@ extern int ykclient_verify_otp_v2 (ykclient_t * ykc_in,
 				   const char *hexkey,
 				   size_t urlcount,
 				   const char **urls, const char *api_key);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
I was writing a YubiKey module for ZNC (An IRC bouncer) and its since ZNC is C++ I had to wrap the include in extern "C". https://gist.github.com/1217088
