### PR TITLE
Add option to specify CA path

### DIFF
--- a/tool.c
+++ b/tool.c
@@ -1,6 +1,7 @@
 /* tool.c --- Command line interface to libykclient.
  *
  * Copyright (c) 2006-2012 Yubico AB
+ * Copyright (c) 2012 Secure Mission Solutions
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Add the --ca option to the utility to allow users to specify a separate
CA path
