### PR TITLE
Fix warnings when compiled with clang 4.0

### DIFF
--- a/ykclient.c
+++ b/ykclient.c
@@ -652,7 +652,7 @@ ykclient_request (ykclient_t * ykc, const char *yubikey)
 
   still_running = num_templates;
   while(still_running) {
-    CURLcode curl_ret = curl_multi_perform (curl, &still_running);
+    CURLMcode curl_ret = curl_multi_perform (curl, &still_running);
     struct timeval timeout;
 
     fd_set fdread;


### PR DESCRIPTION
When compiled with 

Apple clang version 4.0 (tags/Apple/clang-421.0.60) (based on LLVM 3.1svn)
Target: x86_64-apple-darwin12.1.0
Thread model: posix

yubico-c-client causes a tautological compare warning and a conversion warning fixed by the two commits attached.
