### PR TITLE
configure.ac: Call AM_PROG_AR if available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,9 +41,7 @@ AM_INIT_AUTOMAKE([1.10 -Wall -Werror])
 AM_SILENT_RULES([yes])
 AC_PROG_CC
 
-# needed for automake 1.12 and other workarounds break 1.11...
-m4_pattern_allow([AM_PROG_AR])
-AM_PROG_AR
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
 AC_LIBTOOL_WIN32_DLL
 AC_PROG_LIBTOOL


### PR DESCRIPTION
As mentioned in pull request #8, let's use

``` autoconf
m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
```

I can confirm this works with automake 1.13 (and probably also 1.12).
