### PR TITLE
Lovin on the yubico-c-client tranche 2

### DIFF
--- a/ykclient.c
+++ b/ykclient.c
@@ -1062,6 +1062,10 @@ ykclient_request_send (ykclient_t * ykc, ykclient_handle_t * ykh,
   int requests;
   ykclient_server_response_t *srv_response = NULL;
   
+  if (!ykc->num_templates) {
+    return YKCLIENT_MISSING_PARAMETER;
+  }
+
   /* The handle must have the same number of easy handles as we have templates */
   if (ykc->num_templates != ykh->num_easy) {
     return YKCLIENT_HANDLE_NOT_REINIT;
@@ -1070,12 +1074,10 @@ ykclient_request_send (ykclient_t * ykc, ykclient_handle_t * ykh,
   memset (ykc->last_url, 0, sizeof (ykc->last_url));
 
   /* Perform the request */
-  requests = ykc->num_templates;
-  while (requests)
-  {
+  do {
+    int msgs = 1;
     CURLMcode curl_ret = curl_multi_perform (ykh->multi, &requests);
     struct timeval timeout;
-    int msgs = 1;
 
     fd_set fdread;
     fd_set fdwrite;
@@ -1102,6 +1104,8 @@ ykclient_request_send (ykclient_t * ykc, ykclient_handle_t * ykh,
     FD_ZERO (&fdwrite);
     FD_ZERO (&fdexcep);
 
+    memset(&timeout, 0, sizeof(timeout));
+    
     timeout.tv_sec = 0;
     timeout.tv_usec = 250000;
 
@@ -1122,101 +1126,105 @@ ykclient_request_send (ykclient_t * ykc, ykclient_handle_t * ykh,
 
     curl_multi_fdset (ykh->multi, &fdread, &fdwrite, &fdexcep, &maxfd);
     select (maxfd+1, &fdread, &fdwrite, &fdexcep, &timeout);
-    
+
     while (msgs)
     {
-      CURLMsg *msg = curl_multi_info_read (ykh->multi, &msgs);
-      if (msg && msg->msg == CURLMSG_DONE)
-      {
-        CURL *curl_easy = msg->easy_handle;
-        struct curl_data *data;
-        char *url_used;
-        char *status;
+      CURL *curl_easy;
+      struct curl_data *data;
+      char *url_used;
+      char *status;
+      CURLMsg *msg;
 
-        curl_easy_getinfo (curl_easy, CURLINFO_PRIVATE, (char **) &data);
-
-        if (data == 0 || data->curl_chunk_size == 0 || 
-            data->curl_chunk == NULL)
-        {
-          out = YKCLIENT_PARSE_ERROR;
-          goto finish;
-        }
-
-        curl_easy_getinfo (curl_easy, CURLINFO_EFFECTIVE_URL, &url_used);
-        strncpy (ykc->last_url, url_used, sizeof(ykc->last_url));
-
-        srv_response = ykclient_server_response_init ();
-        if (srv_response == NULL)
-        {
-          out = YKCLIENT_PARSE_ERROR;
-          goto finish;
-        }
-          
-        out = ykclient_server_response_parse (data->curl_chunk, 
-            srv_response);
-        if (out != YKCLIENT_OK)
-        {
-          goto finish;
-        }
-
-        if (ykc->verify_signature != 0 &&
-            ykclient_server_response_verify_signature (srv_response,
-                ykc->key, ykc->keylen))
-        {
-          out = YKCLIENT_BAD_SERVER_SIGNATURE;
-          goto finish;
-        }
-
-        status = ykclient_server_response_get (srv_response, "status");
-        if (!status)
-        {
-          out = YKCLIENT_PARSE_ERROR;
-          goto finish;
-        }
-
-        out = ykclient_parse_srv_error (status);
-        if (out == YKCLIENT_OK)
-        {
-          char *server_otp;
-
-          /* Verify that the OTP and nonce we put in our request is echoed 
-           * in the response.
-           *
-           * This is to protect us from a man in the middle sending us a 
-           * previously seen genuine response again (such as an status=OK 
-           * response even though the real server will respond 
-           * status=REPLAYED_OTP in a few milliseconds.
-           */
-          if (nonce)
-          {
-             char *server_nonce = ykclient_server_response_get (srv_response, 
-                  "nonce");
-             if (server_nonce == NULL || strcmp (nonce, server_nonce))
-             {
-               out = YKCLIENT_HMAC_ERROR;
-               goto finish;
-             }
-          }
-
-          server_otp = ykclient_server_response_get (srv_response, "otp");
-          if (server_otp == NULL || strcmp (yubikey, server_otp))
-          {
-            out = YKCLIENT_HMAC_ERROR;
-          }  
-          
-          goto finish;
-        }
-        else if ((out != YKCLIENT_PARSE_ERROR) && 
-                 (out != YKCLIENT_REPLAYED_REQUEST))
-        {
-          goto finish;
-        }
-
-        ykclient_server_response_free (srv_response);
-        srv_response = NULL;
+      msg = curl_multi_info_read (ykh->multi, &msgs);
+      if (!msg || msg->msg != CURLMSG_DONE) {
+        continue;
       }
+      
+      curl_easy = msg->easy_handle;
+
+      curl_easy_getinfo (curl_easy, CURLINFO_PRIVATE, (char **) &data);
+
+      if (data == 0 || data->curl_chunk_size == 0 || 
+          data->curl_chunk == NULL)
+      {
+        out = YKCLIENT_PARSE_ERROR;
+        goto finish;
+      }
+
+      curl_easy_getinfo (curl_easy, CURLINFO_EFFECTIVE_URL, &url_used);
+      strncpy (ykc->last_url, url_used, sizeof(ykc->last_url));
+
+      srv_response = ykclient_server_response_init ();
+      if (srv_response == NULL)
+      {
+        out = YKCLIENT_PARSE_ERROR;
+        goto finish;
+      }
+        
+      out = ykclient_server_response_parse (data->curl_chunk, 
+          srv_response);
+      if (out != YKCLIENT_OK)
+      {
+        goto finish;
+      }
+
+      if (ykc->verify_signature != 0 &&
+          ykclient_server_response_verify_signature (srv_response,
+              ykc->key, ykc->keylen))
+      {
+        out = YKCLIENT_BAD_SERVER_SIGNATURE;
+        goto finish;
+      }
+
+      status = ykclient_server_response_get (srv_response, "status");
+      if (!status)
+      {
+        out = YKCLIENT_PARSE_ERROR;
+        goto finish;
+      }
+
+      out = ykclient_parse_srv_error (status);
+      if (out == YKCLIENT_OK)
+      {
+        char *server_otp;
+
+        /* Verify that the OTP and nonce we put in our request is echoed 
+         * in the response.
+         *
+         * This is to protect us from a man in the middle sending us a 
+         * previously seen genuine response again (such as an status=OK 
+         * response even though the real server will respond 
+         * status=REPLAYED_OTP in a few milliseconds.
+         */
+        if (nonce)
+        {
+           char *server_nonce = ykclient_server_response_get (srv_response, 
+                "nonce");
+           if (server_nonce == NULL || strcmp (nonce, server_nonce))
+           {
+             out = YKCLIENT_HMAC_ERROR;
+             goto finish;
+           }
+        }
+
+        server_otp = ykclient_server_response_get (srv_response, "otp");
+        if (server_otp == NULL || strcmp (yubikey, server_otp))
+        {
+          out = YKCLIENT_HMAC_ERROR;
+        }  
+        
+        goto finish;
+      }
+      else if ((out != YKCLIENT_PARSE_ERROR) && 
+               (out != YKCLIENT_REPLAYED_REQUEST))
+      {
+        goto finish;
+      }
+
+      ykclient_server_response_free (srv_response);
+      srv_response = NULL;
     }
-  }
+  } while (requests);
 finish:
   if (srv_response)
   {
@@ -1248,7 +1256,7 @@ ykclient_get_last_url (ykclient_t * ykc)
  */
 ykclient_rc
 ykclient_request_process (ykclient_t * ykc, ykclient_handle_t * ykh,
-                         const char *yubikey)
+                          const char *yubikey)
 {
   ykclient_rc out;
   char *nonce = NULL;


### PR DESCRIPTION
OK so not as bad as the first one.

Real world testing threw up a few issues that the test suite didn't catch. Seems timing is actually pretty important with libcurl, and if you jump out of processing the request early before all servers have responded it will close the underlying TCP connection.

I modified our server pool code to have a special connection selection mode where it will use the connection that has been idle the longest, and only perform cleanup when it's about to make a new request.

That, combined with the fixes in this pull request, get connection re-use up to 100% with non of the nasty hard resets you got in the original code.

![Screen Shot 2013-04-11 at 18 44 32](https://f.cloud.github.com/assets/791758/370607/741af096-a2f9-11e2-8365-99e078b072b4.png)

![Screen Shot 2013-04-11 at 18 44 18](https://f.cloud.github.com/assets/791758/370606/70b3de7c-a2f9-11e2-99ab-c1a1c7e31690.png)
