### PR TITLE
If any requests come back connection refused, skip over them.

### DIFF
--- a/ykclient.c
+++ b/ykclient.c
@@ -1248,6 +1248,22 @@ ykclient_request_send (ykclient_t * ykc, ykclient_handle_t * ykh,
 	      continue;
 	    }
 
+	  // msg->msg must == CURLMSG_DONE so data.result contains important information
+	  switch (msg->data.result) {
+	    case CURLE_OK:
+	      break;
+	    case CURLE_COULDNT_CONNECT: //eg connection refused
+	      //We MUST set out here or validation will suceed when all validation servers are shutdown.
+	      out=YKCLIENT_CURL_PERFORM_ERROR;
+	      continue;
+	    case CURLE_COULDNT_RESOLVE_HOST:
+	      out=YKCLIENT_CURL_PERFORM_ERROR;
+	      continue;
+	    default:
+	      fprintf (stderr, "data.result = %d\n",msg->data.result);
+	      break;
+	  }
+
 	  curl_easy = msg->easy_handle;
 
 	  curl_easy_getinfo (curl_easy, CURLINFO_PRIVATE, (char **) &data);


### PR DESCRIPTION
Note 'out' is initialised as 'YKCLIENT_OK', so it is vital
to set it to something else before continuing

Perhaps I should have used a different/new return code?
msg->data.result can be lots of other things too. http://curl.haxx.se/libcurl/c/libcurl-errors.html

I've only caught CURLE_OK and two error conditions specifically.

This addresses https://github.com/Yubico/yubico-c-client/issues/25
