### PR TITLE
Default URL templates now use SSL to prevent tampering

### DIFF
--- a/ykclient.c
+++ b/ykclient.c
@@ -89,11 +89,11 @@ struct ykclient_handle_st
 };
 
 const char *default_url_templates[] = {
-  "http://api.yubico.com/wsapi/2.0/verify",
-  "http://api2.yubico.com/wsapi/2.0/verify",
-  "http://api3.yubico.com/wsapi/2.0/verify",
-  "http://api4.yubico.com/wsapi/2.0/verify",
-  "http://api5.yubico.com/wsapi/2.0/verify",
+  "https://api.yubico.com/wsapi/2.0/verify",
+  "https://api2.yubico.com/wsapi/2.0/verify",
+  "https://api3.yubico.com/wsapi/2.0/verify",
+  "https://api4.yubico.com/wsapi/2.0/verify",
+  "https://api5.yubico.com/wsapi/2.0/verify",
 };
 
 /** Initialise the global context for the library


### PR DESCRIPTION
After doing some unrelated debugging on a server I discovered that pam_yubico communicates in plaintext with the Yubico API if the urllist isn't overridden.

The documentation at https://developers.yubico.com/yubico-pam/ indicates that the default is SSL secured e.g. https://api.yubico.com/wsapi/verify?id=%d&otp=%s

The various certificates for each API hostname are successfully validated when tested on a workstation with ca-certificates-2013.1.97-1.fc20.noarch and curl-7.32.0-17.fc20.x86_64 so should be safe to merge (unless I've missed something?)