### PR TITLE
Add proxy support via Curl

### DIFF
--- a/libykclient.map
+++ b/libykclient.map
@@ -69,4 +69,5 @@ YKCLIENT_2.12 {
 YKCLIENT_2.15 {
   global:
     ykclient_get_server_response;
+    ykclient_set_proxy;
 } YKCLIENT_2.12;

--- a/ykclient.c
+++ b/ykclient.c
@@ -61,6 +61,7 @@ struct ykclient_st
 {
   const char *ca_path;
   const char *ca_info;
+  const char *proxy;
   size_t num_templates;
   char **url_templates;
   int template_format;
@@ -154,6 +155,7 @@ ykclient_init (ykclient_t ** ykc)
 
   p->ca_path = NULL;
   p->ca_info = NULL;
+  p->proxy = NULL;
 
   p->key = NULL;
   p->keylen = 0;
@@ -327,6 +329,17 @@ ykclient_handle_init (ykclient_t * ykc, ykclient_handle_t ** ykh)
       if (ykc->ca_info)
 	{
 	  curl_easy_setopt (easy, CURLOPT_CAINFO, ykc->ca_info);
+	}
+
+      if (ykc->proxy)
+	{
+	  /*
+	   *  The proxy string may be prefixed with [scheme]://ip:port to specify which kind of proxy is used.
+	   *  Valid choices are: socks4://, socks4a://, socks5:// or socks5h://
+	   *  Use socks5h to ask the proxy to do the dns resolving.
+	   *  If no scheme or port is specified HTTP proxy port 1080 will be used.
+	   */
+	  curl_easy_setopt (easy, CURLOPT_PROXY, ykc->proxy);
 	}
 
       curl_easy_setopt (easy, CURLOPT_WRITEDATA, (void *) data);
@@ -575,6 +588,17 @@ ykclient_set_ca_info (ykclient_t * ykc, const char *ca_info)
 {
   ykc->ca_info = ca_info;
 }
+
+/** Set the proxy
+ *
+ * Must be called before creating handles.
+ */
+void
+ykclient_set_proxy (ykclient_t * ykc, const char *proxy)
+{
+  ykc->proxy = proxy;
+}
+
 
 /** Set a single URL template
  *

--- a/ykclient.h
+++ b/ykclient.h
@@ -97,6 +97,8 @@ extern "C"
 
   extern void ykclient_set_ca_info (ykclient_t * ykc, const char *ca_info);
 
+  extern void ykclient_set_proxy (ykclient_t * ykc, const char *proxy);
+
 /*
  * Set the nonce. A default nonce is generated in ykclient_init(), but
  * if you either want to specify your own nonce, or want to remove the


### PR DESCRIPTION
Command line usage:  `--proxy=socks5h://user:pass@10.10.0.1:1080`
Adds libykclient function: `ykclient_set_proxy`

Valid Curl schemes are: `socks4://`, `socks4a://`, `socks5://` or `socks5h://` (the last one to enable socks5 and asking the proxy to do the dns resolving). If no scheme or port is specified HTTP proxy port 1080 will be used per Curl defaults. 

This addresses #35. Thanks.