### PR TITLE
Adds autotools option for building without documentation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,7 +65,7 @@ ykclient_SOURCES = tool.c
 ykclient_LDADD = ./libykclient.la
 
 # Man page
-
+if ENABLE_DOC
 dist_man_MANS = ykclient.1
 DISTCLEANFILES = $(dist_man_MANS)
 
@@ -74,6 +74,7 @@ ykclient.1: $(ykclient_SOURCES) $(srcdir)/configure.ac | $(builddir)/ykclient$(E
 		--output=$@ $(builddir)/ykclient$(EXEEXT) \
 		--name="YubiCloud One-Time-Password Validation Client" \
 		--no-info
+endif
 
 if ENABLE_COV
 AM_CFLAGS += --coverage

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,15 @@ gl_VALGRIND_TESTS
 
 PKG_CHECK_MODULES([LIBCURL], [libcurl])
 
+# --disable-documentation
+AC_ARG_ENABLE([documentation],
+	      [AS_HELP_STRING([--disable-documentation],
+			     [do not build documentation])],
+			     [enable_doc="${enableval}" ],
+			     [enable_doc="yes"])
+AM_CONDITIONAL(ENABLE_DOC, test "$enable_doc" != "no")
+
+# --enable-coverage
 AC_ARG_ENABLE([coverage],
               [AS_HELP_STRING([--enable-coverage],
                               [use Gcov to test the test suite])],


### PR DESCRIPTION
- removes help2man dependency used for man page generation by configuring with:
  ./configure --disable-documentation